### PR TITLE
updated examples in functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,8 +12,6 @@ Description: The BWASP workflow for BS-seq data analysis produces methylation
 Depends: R (>= 3.3.2)
 Imports:
    BiocGenerics,
-   circlize,
-   ComplexHeatmap,
    dplyr,
    genomation,
    GenomicRanges,

--- a/R/annotate_methylome.R
+++ b/R/annotate_methylome.R
@@ -26,7 +26,7 @@
 
 
 annotate_methylome <- function(mrobj,
-                               genome_ann,destrand=TRUE,
+                               genome_ann,destrand=FALSE,
                                outfile="methylome_ann.txt"
                               ){
     # ... unite all the methlRawList object into a methylBase object and calculate

--- a/R/det_dmsg.R
+++ b/R/det_dmsg.R
@@ -35,7 +35,7 @@
 #' @export
 
 det_dmsg <- function(mrobj,genome_ann,threshold=25.0,qvalue=0.01,mc.cores=1,
-                     destrand=TRUE,
+                     destrand=FALSE,
                      outfile1="methyl_dmsites.txt",
                      outfile2="methyl_dmgenes.txt"){
     sample_list <- getSampleID(mrobj)

--- a/R/explore_dmsg.R
+++ b/R/explore_dmsg.R
@@ -99,7 +99,8 @@ explore_dmsg <- function(mrobj,genome_ann,show_dmsg){
 	# order the genes by diff_meth_10kb
         summary <- summary[order(- summary$diff_meth_10kb),]
         write.table(summary, 
-                    paste(comparison,'explore_dmsg.txt',sep='_'),sep='\t')
+                    paste(comparison,'explore_dmsg.txt',sep='_'),sep='\t',
+                          quote=FALSE)
     })
     message('... explore_dmsg finished ...')
 }

--- a/man/annotate_methylome.Rd
+++ b/man/annotate_methylome.Rd
@@ -5,7 +5,7 @@
 \title{annotate_methylome()
 This function annotates the methylome with different genomic features (e.g. genes, exon, promoter, etc.)}
 \usage{
-annotate_methylome(mrobj, genome_ann, destrand = TRUE,
+annotate_methylome(mrobj, genome_ann, destrand = FALSE,
   outfile = "methylome_ann.txt")
 }
 \arguments{

--- a/man/det_dmsg.Rd
+++ b/man/det_dmsg.Rd
@@ -7,7 +7,7 @@
   corresponding genes, as determined by application of methylKit functions.}
 \usage{
 det_dmsg(mrobj, genome_ann, threshold = 25, qvalue = 0.01, mc.cores = 1,
-  destrand = TRUE, outfile1 = "methyl_dmsites.txt",
+  destrand = FALSE, outfile1 = "methyl_dmsites.txt",
   outfile2 = "methyl_dmgenes.txt")
 }
 \arguments{

--- a/man/show_dmsg.Rd
+++ b/man/show_dmsg.Rd
@@ -5,7 +5,7 @@
 \title{show_dmsg() 
   This function generates will plot heatmaps of methylation level of sites in dmgenes}
 \usage{
-show_dmsg(mrobj, dmsg, min.nsites = 2, destrand = TRUE)
+show_dmsg(mrobj, dmsg, min.nsites = 2, destrand = FALSE, outflabel = "")
 }
 \arguments{
 \item{mrobj}{A methyRaw object or a methyRawList object}
@@ -29,13 +29,16 @@ show_dmsg()
   mydatf <- system.file("extdata","Am.dat",package="BWASPR")
   myparf <- system.file("extdata","Am.par",package="BWASPR")
   myfiles <- setup_BWASPR(datafile=mydatf,parfile=myparf)
+  samplelist <- list("forager","nurse")
   AmHE <- mcalls2mkobj(myfiles$datafiles,species="Am",study="HE",
+                       sample=samplelist,replicate=c(0),
                        type="CpGhsm",mincov=1,assembly="Amel-4.5")
   genome_ann <- get_genome_annotation(myfiles$parameters)
-  meth_diff <- det_dmsg(AmHE,genome_ann,
-                        threshold=25.0,qvalue=0.01,mc.cores=4,
-                        outfile1="AmHE-dmsites.txt", 
-                        outfile2="AmHE-dmgenes.txt")
-  show_dmsg <- show_dmsg(AmHE,meth_diff)
+  dmsgList <- det_dmsg(AmHE,genome_ann,
+                       threshold=25.0,qvalue=0.01,mc.cores=4,destrand=TRUE,
+                       outfile1="AmHE-dmsites.txt", 
+                       outfile2="AmHE-dmgenes.txt")
+  show_dmsg <- show_dmsg(AmHE,dmsgList,min.nsites=2,destrand=TRUE,
+                         outflabel="Am_HE")
 
 }


### PR DESCRIPTION
Small updates:

destrand=FALSE default to be consistent throughout and with methylKit

output file naming for show_dmsg() made consistent with other conventions

updates to examples in function descriptions to make things work