### PR TITLE
add a column to calculate the DMperNucl without abs()

### DIFF
--- a/R/explore_dmsg.R
+++ b/R/explore_dmsg.R
@@ -141,6 +141,7 @@ explore_dmsg <- function(mrobj,genome_ann,dmgprp,withglink="NCBIgene",
                           nbrdmper10kb = round((nbrdmsites/gwidth)*10000,2),
                           prcntdm = round((nbrdmsites/nbrsites)*100,2),
                           admpersite = round(abs(sum(sample1)-sum(sample2))/nbrsites,2),
+                          dmpernucl = round((sum(sample1)-sum(sample2))/gwidth,2),
                           admpernucl = round(abs(sum(sample1)-sum(sample2))/gwidth,2)
                          )
         }
@@ -152,7 +153,8 @@ explore_dmsg <- function(mrobj,genome_ann,dmgprp,withglink="NCBIgene",
                           nbrdmsites = sum(is.dm),
                           nbrdmper10kb = round((nbrdmsites/gwidth)*10000,2),
                           prcntdm = round((nbrdmsites/nbrsites)*100,2),
-                          admpersite = round(abs(sum(sample1)-sum(sample2))/nbrsites,2),
+                          admpernucl = round((sum(sample1)-sum(sample2))/gwidth,2),
+                          dmpersite = round((sum(sample1)-sum(sample2))/gwidth,2),
                           admpernucl = round(abs(sum(sample1)-sum(sample2))/gwidth,2)
                          )
         }
@@ -161,12 +163,12 @@ explore_dmsg <- function(mrobj,genome_ann,dmgprp,withglink="NCBIgene",
         if (nchar(withglink) > 0) {
             colnames(pw_summary) <-
               c("gene_ID","gene_link","gwidth","#Sites","#per10Kb",
-                "#dmSites","#dmsp10kb","%dmSites","ADMpSite","ADMpNucl")
+                "#dmSites","#dmsp10kb","%dmSites","ADMpSite","DMpNucl","ADMpNucl")
         }
         else {
             colnames(pw_summary) <-
               c("gene_ID","gwidth","#Sites","#per10Kb",
-                "#dmSites","#dmsp10kb","%dmSites","ADMpSite","ADMpNucl")
+                "#dmSites","#dmsp10kb","%dmSites","ADMpSite","DMpNucl","ADMpNucl")
         }
         outfile <- paste("ogl",outflabel,sep="-")
         outfile <- paste(outfile,comparison,sep="_")


### PR DESCRIPTION
a modification in explore_dmsg() to calculate the DMperNucl in pw comparisons